### PR TITLE
Ignore Markdown Files While Pushing Or Pull Request

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -4,9 +4,13 @@ on:
   push:
     branches:
       - dev
+    paths-ignore:
+      - '**.md'
   pull_request:
     branches:
       - dev
+    paths-ignore:
+      - '**.md'
 
 jobs:
   build:


### PR DESCRIPTION
While pushing (committing) or pull requesting the workflow starts. But it is annoying when it comes to markdown files (Readme and Readmeme). If you merge this to dev branch, you can solve it